### PR TITLE
Removing extra as it can overflow some session stores

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -6,7 +6,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Google'
       sign_in_and_redirect @user, event: :authentication
     else
-      session['devise.google_data'] = request.env['omniauth.auth']
+      session['devise.google_data'] = request.env['omniauth.auth'].except(:extra)
       return render 'new', locals: { user: @user, projects: @projects }
     end
   end


### PR DESCRIPTION
Added 
#### Removing extra as it can overflow some session stores
`session['devise.google_data'] = request.env['omniauth.auth'].except(:extra)`